### PR TITLE
fix parseVast pathname

### DIFF
--- a/.specless/src/modules/utils/placement.js
+++ b/.specless/src/modules/utils/placement.js
@@ -1,4 +1,4 @@
 export { panelUrl } from './../../utils/panelUrl.js';
-export { parseVAST } from './../../utils/parseVAST.js';
+export { parseVAST } from './../../utils/parseVast.js';
 export { createUseStyles } from 'react-jss';
 export { getLayout } from './../../utils/getLayout.js';

--- a/.specless/src/modules/utils/specless.js
+++ b/.specless/src/modules/utils/specless.js
@@ -1,6 +1,6 @@
 import { getLayout as _getLayout } from './../../utils/getLayout.js';
 import { createUseStyles as _createUseStyles } from 'react-jss';
-import { parseVAST as _parseVAST } from './../../utils/parseVAST.js';
+import { parseVAST as _parseVAST } from './../../utils/parseVast.js';
 const utils = {
     getLayout: _getLayout,
     createUseStyles: _createUseStyles,


### PR DESCRIPTION
Fixes the pathname for parseVast.js since certain systems are case-sensitive.